### PR TITLE
Add PHP 8.5 support

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -18,7 +18,7 @@ jobs:
                 name: Setup PHP
                 uses: shivammathur/setup-php@v2
                 with:
-                    php-version: 8.4
+                    php-version: 8.5
             -
                 name: Install dependencies
                 run: composer install --no-progress --prefer-dist --no-interaction
@@ -32,7 +32,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php-version: [ '8.2', '8.3', '8.4' ]
+                php-version: [ '8.2', '8.3', '8.4', '8.5' ]
                 dependency-version: [ prefer-lowest, prefer-stable ]
         steps:
             -


### PR DESCRIPTION
## Summary
- Add PHP 8.5 to the CI test matrix

## Test plan
- CI will run tests on PHP 8.5