### PR TITLE
Allow Symfony 8 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,12 +19,12 @@
         "shipmonk/composer-dependency-analyser": "^1.8.2",
         "shipmonk/name-collision-detector": "^2.1.1",
         "shipmonk/phpstan-rules": "^4.1.1",
-        "symfony/browser-kit": "^7.2",
-        "symfony/dependency-injection": "^7.2",
-        "symfony/framework-bundle": "^7.2",
-        "symfony/http-foundation": "^7.2",
-        "symfony/http-kernel": "^7.2",
-        "symfony/routing": "^7.2"
+        "symfony/browser-kit": "^7.2 || ^8.0",
+        "symfony/dependency-injection": "^7.2 || ^8.0",
+        "symfony/framework-bundle": "^7.2 || ^8.0",
+        "symfony/http-foundation": "^7.2 || ^8.0",
+        "symfony/http-kernel": "^7.2 || ^8.0",
+        "symfony/routing": "^7.2 || ^8.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
## Summary
Updated all symfony/* package constraints in require-dev to support Symfony 8.

## Changes
- Updated 6 Symfony packages to allow both ^7.2 and ^8.0 versions:
  - symfony/browser-kit
  - symfony/dependency-injection
  - symfony/framework-bundle
  - symfony/http-foundation
  - symfony/http-kernel
  - symfony/routing

## Test plan
- Verify composer.json changes are correct
- Run `composer update` to ensure no conflicts
- Run test suite to ensure compatibility